### PR TITLE
Don't display help string when an error occurs

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -38,6 +38,8 @@ func GetRootCommand() *cobra.Command {
 		Use:                    "onos",
 		Short:                  "ONOS command line client",
 		BashCompletionFunction: getBashCompletions(),
+		SilenceUsage:           true,
+		SilenceErrors:          true,
 	}
 	cmd.AddCommand(config.GetCommand())
 	cmd.AddCommand(topo.GetCommand())


### PR DESCRIPTION
This PR disables Cobra display of help information when an error occurs. This is needed for conversion of Run() methods to RunE() methods
