### PR TITLE
Added the python based `gnmi-cli-stratum` to the system

### DIFF
--- a/build/onos/Dockerfile
+++ b/build/onos/Dockerfile
@@ -7,8 +7,40 @@ RUN go get github.com/openconfig/gnmi/cmd/gnmi_cli && \
 COPY . /go/src/github.com/onosproject/onos-cli
 RUN cd /go/src/github.com/onosproject/onos-cli && GOFLAGS=-mod=vendor make build
 
-FROM alpine:3.9
-RUN apk add bash bash-completion curl libc6-compat
+FROM python:alpine3.10 as pybuilder
+
+RUN apk update
+RUN apk add git python3-dev build-base
+RUN pip3 install --install-option="--prefix=/install" grpcio protobuf
+RUN pip3 install grpcio-tools
+
+ENV PYTHONPATH="/install/lib/python3.7/site-packages"
+
+# Change back to official one after they fix this
+# RUN git clone https://github.com/openconfig/gnmi
+RUN git clone https://github.com/bocon13/gnmi
+RUN git clone https://github.com/bocon13/Yi-s-gNMI-tool.git
+RUN git clone https://github.com/google/protobuf
+
+ENV proto_imports=.:/protobuf/src
+
+RUN cd gnmi/proto && \
+    python -m grpc_tools.protoc -I=$proto_imports --python_out=.                     gnmi_ext/gnmi_ext.proto && \
+    python -m grpc_tools.protoc -I=$proto_imports --python_out=. --grpc_python_out=. gnmi/gnmi.proto && \
+    python -m grpc_tools.protoc -I=$proto_imports --python_out=.                     target/target.proto
+
+RUN mv /gnmi/proto/gnmi $PYTHONPATH/ && \
+    touch $PYTHONPATH/gnmi/__init__.py
+RUN mv /gnmi/proto/gnmi_ext $PYTHONPATH/ && \
+    touch $PYTHONPATH/gnmi_ext/__init_.py
+RUN mv /gnmi/proto/target $PYTHONPATH/ && \
+    touch $PYTHONPATH/target
+
+# Python is only added here so that we can use the Stratum gnmi-cli.py
+# When Stratum implements TLS we will be able to use the go gnmi_cli
+# and this should be removed
+FROM python:3.7-alpine3.10
+RUN apk add --no-cache bash bash-completion curl libc6-compat libstdc++
 
 RUN addgroup -S onos && adduser -S -G onos onos
 USER onos
@@ -18,6 +50,9 @@ COPY --from=build /go/src/github.com/onosproject/onos-cli/build/_output/onos /us
 COPY --from=build /go/bin/atomix /usr/local/bin/atomix
 COPY --from=build /go/bin/gnmi_cli /usr/local/bin/gnmi_cli
 COPY --from=build /go/src/github.com/onosproject/onos-cli/pkg/certs/* /etc/ssl/certs/
+
+COPY --from=pybuilder /install /usr/local
+COPY --from=pybuilder Yi-s-gNMI-tool/gnmi-cli.py /usr/local/bin/gnmi-cli-stratum
 
 RUN mkdir /home/onos/.onos && \
     cp /etc/profile /home/onos/.bashrc && \


### PR DESCRIPTION
I called it `gnmi-cli-stratum` so as not to clash with the `gnmi_cli` command

Python stuff is a pain to build, but I don't think it can be done much simpler.