### PR TITLE
Add a command to set report period for kpimon app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/goveralls v0.0.7 // indirect
 	github.com/onosproject/onos-api/go v0.7.0
 	github.com/onosproject/onos-lib-go v0.7.0
-	github.com/onosproject/onos-ric-sdk-go v0.7.0
+	github.com/onosproject/onos-ric-sdk-go v0.7.1
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
 	github.com/spf13/cobra v1.1.1
 	github.com/yookoala/realpath v1.0.0 // indirect
@@ -18,5 +18,3 @@ require (
 )
 
 replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.20200229013735-71373c6105e3
-
-replace github.com/onosproject/onos-ric-sdk-go => ../onos-ric-sdk-go

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 )
 
 replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.20200229013735-71373c6105e3
+
+replace github.com/onosproject/onos-ric-sdk-go => ../onos-ric-sdk-go

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onosproject/onos-ric-sdk-go v0.7.1 h1:cZJT6zcC7BzzGzAyoZw3vdBI6Wi8BW5rwd7jHf49My4=
+github.com/onosproject/onos-ric-sdk-go v0.7.1/go.mod h1:ep1Fe1OUcmKi4zzyFHhYr0dWcE5aPD7nQJn8Q50b2VU=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802 h1:WXFwJlWOJINlwlyAZuNo4GdYZS6qPX36+rRUncLmN8Q=

--- a/pkg/kpimon/crud.go
+++ b/pkg/kpimon/crud.go
@@ -24,3 +24,12 @@ func getListCommand() *cobra.Command {
 	cmd.AddCommand(getListNumActiveUEsCommand())
 	return cmd
 }
+
+func getSetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set {report_interval} [args]",
+		Short: "Set KPIMON parameters",
+	}
+	cmd.AddCommand(setReportIntervalCommand())
+	return cmd
+}

--- a/pkg/kpimon/kpi.go
+++ b/pkg/kpimon/kpi.go
@@ -17,10 +17,11 @@ package kpimon
 import (
 	"context"
 	"fmt"
+	"text/tabwriter"
+
 	kpimonapi "github.com/onosproject/onos-api/go/onos/kpimon"
 	"github.com/onosproject/onos-lib-go/pkg/cli"
 	"github.com/spf13/cobra"
-	"text/tabwriter"
 )
 
 func getListNumActiveUEsCommand() *cobra.Command {

--- a/pkg/kpimon/report_interval.go
+++ b/pkg/kpimon/report_interval.go
@@ -138,7 +138,7 @@ func runSetReportIntervalCommand(cmd *cobra.Command, args []string) error {
 	writer := new(tabwriter.Writer)
 	writer.Init(outputWriter, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	if err == nil {
-		_, _ = fmt.Fprintf(writer, "Report period interval is set to %d successfully\n", interval)
+		_, _ = fmt.Fprintf(writer, "Report period interval is set to %d ms successfully\n", interval)
 	} else {
 		_, _ = fmt.Fprintf(writer, "%v\n", err)
 	}

--- a/pkg/kpimon/report_interval.go
+++ b/pkg/kpimon/report_interval.go
@@ -34,7 +34,7 @@ import (
 	"github.com/onosproject/onos-lib-go/pkg/certs"
 	"github.com/onosproject/onos-lib-go/pkg/cli"
 	gclient "github.com/openconfig/gnmi/client/gnmi"
-	pb "github.com/openconfig/gnmi/proto/gnmi"
+	gnmi "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/spf13/cobra"
 )
 
@@ -104,12 +104,13 @@ func runSetReportIntervalCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	val := pb.TypedValue_UintVal{interval}
+	val := gnmi.TypedValue_UintVal{
+		UintVal: interval}
 
-	update := &pb.Update{}
+	update := &gnmi.Update{}
 	update.Path = pbPath
 	update.Path.Target = "onos-kpimon"
-	update.Val = &pb.TypedValue{
+	update.Val = &gnmi.TypedValue{
 		Value: &val,
 	}
 	extVersion := gnmi_ext.Extension_RegisteredExt{
@@ -127,8 +128,8 @@ func runSetReportIntervalCommand(cmd *cobra.Command, args []string) error {
 
 	extensions := []*gnmi_ext.Extension{{Ext: &extVersion}, {Ext: &extModel}}
 
-	request := &pb.SetRequest{
-		Update:    []*pb.Update{update},
+	request := &gnmi.SetRequest{
+		Update:    []*gnmi.Update{update},
 		Extension: extensions,
 	}
 

--- a/pkg/kpimon/report_interval.go
+++ b/pkg/kpimon/report_interval.go
@@ -1,0 +1,148 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kpimon
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"strconv"
+	"text/tabwriter"
+	"time"
+
+	"github.com/onosproject/onos-ric-sdk-go/pkg/config/utils"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/openconfig/gnmi/proto/gnmi_ext"
+
+	"github.com/openconfig/gnmi/client"
+
+	"github.com/onosproject/onos-lib-go/pkg/certs"
+	"github.com/onosproject/onos-lib-go/pkg/cli"
+	gclient "github.com/openconfig/gnmi/client/gnmi"
+	pb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/spf13/cobra"
+)
+
+const (
+	onosConfigAddress  = "onos-config:5150"
+	modelName          = "ric"
+	modelVersion       = "1.0.0"
+	reportIntervalPath = "/report_period/interval"
+	target             = "onos-config"
+)
+
+func setReportIntervalCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report-interval <interval>",
+		Short: "Set report period interval",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runSetReportIntervalCommand,
+	}
+	cmd.Flags().Bool("no-headers", false, "disables output headers")
+	return cmd
+
+}
+
+// getClientCredentials returns the credentials for a service client
+func getClientCredentials() (*tls.Config, error) {
+	cert, err := tls.X509KeyPair([]byte(certs.DefaultClientCrt), []byte(certs.DefaultClientKey))
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true,
+	}, nil
+}
+
+func runSetReportIntervalCommand(cmd *cobra.Command, args []string) error {
+	creds, err := getClientCredentials()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dest := client.Destination{
+		Addrs:   []string{onosConfigAddress},
+		Target:  target,
+		TLS:     creds,
+		Timeout: 10 * time.Second,
+	}
+
+	conn, _ := grpc.Dial(onosConfigAddress, grpc.WithTransportCredentials(credentials.NewTLS(creds)))
+
+	c, err := gclient.NewFromConn(ctx, conn, dest)
+	if err != nil {
+		return err
+	}
+
+	pbPath, err := utils.ToGNMIPath(reportIntervalPath)
+
+	if err != nil {
+		return err
+	}
+
+	interval, err := strconv.ParseUint(args[0], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	val := pb.TypedValue_UintVal{interval}
+
+	update := &pb.Update{}
+	update.Path = pbPath
+	update.Path.Target = "onos-kpimon"
+	update.Val = &pb.TypedValue{
+		Value: &val,
+	}
+	extVersion := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  101,
+			Msg: []byte(modelVersion),
+		},
+	}
+	extModel := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  102,
+			Msg: []byte(modelName),
+		},
+	}
+
+	extensions := []*gnmi_ext.Extension{{Ext: &extVersion}, {Ext: &extModel}}
+
+	request := &pb.SetRequest{
+		Update:    []*pb.Update{update},
+		Extension: extensions,
+	}
+
+	_, err = c.Set(context.Background(), request)
+	outputWriter := cli.GetOutput()
+	writer := new(tabwriter.Writer)
+	writer.Init(outputWriter, 0, 0, 3, ' ', tabwriter.FilterHTML)
+	if err == nil {
+		_, _ = fmt.Fprintf(writer, "Report period interval is set to %d successfully\n", interval)
+	} else {
+		_, _ = fmt.Fprintf(writer, "%v\n", err)
+	}
+	_ = writer.Flush()
+
+	return nil
+
+}

--- a/pkg/kpimon/root.go
+++ b/pkg/kpimon/root.go
@@ -38,12 +38,13 @@ func Init() {
 // GetCommand returns the root command for the RAN service
 func GetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kpimon {get} [args]",
+		Use:   "kpimon {get/set} [args]",
 		Short: "ONOS KPIMON subsystem commands",
 	}
 
 	cli.AddConfigFlags(cmd, defaultAddress)
 	cmd.AddCommand(getListCommand())
+	cmd.AddCommand(getSetCommand())
 	cmd.AddCommand(loglib.GetCommand())
 	return cmd
 


### PR DESCRIPTION
This PR adds the following command that allows us to configure report period interval for the kpimon xApp. 

```
onos kpimon set report-interval <interval value>
```

it should be merged after we merge this: 
https://github.com/onosproject/onos-ric-sdk-go/pull/41