### PR TITLE
Support both representation of plmn ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3
-	github.com/onosproject/onos-api/go v0.7.11
+	github.com/onosproject/onos-api/go v0.7.16
 	github.com/onosproject/onos-lib-go v0.7.5
 	github.com/onosproject/onos-ric-sdk-go v0.7.10
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802

--- a/go.sum
+++ b/go.sum
@@ -242,6 +242,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onosproject/onos-api/go v0.7.5/go.mod h1:Has28v1hruZLUxY1E5cCZq76UHXJZLbh62h1W8KQztQ=
 github.com/onosproject/onos-api/go v0.7.11 h1:P44mC9HbSVljPV+OR6rPZ6vFhJXL8WR6o39mjEIFCFI=
 github.com/onosproject/onos-api/go v0.7.11/go.mod h1:xTlcjPQDGRUMiXtgWDGj9SA6+5pC9qY8B5A1ta9CoZc=
+github.com/onosproject/onos-api/go v0.7.16 h1:694FjmiwejXAEVWbwPCNTVgz3mjALD4R4VaXphxjmhA=
+github.com/onosproject/onos-api/go v0.7.16/go.mod h1:xTlcjPQDGRUMiXtgWDGj9SA6+5pC9qY8B5A1ta9CoZc=
 github.com/onosproject/onos-lib-go v0.7.0/go.mod h1:ttkK+fV2CULZFHiq6FBZ69i7/Nymi1Wow1DNy0Ik/2o=
 github.com/onosproject/onos-lib-go v0.7.5 h1:YsPTsVgxCh+GL2IvSkdkXy7HGFSJuOnubi9mPjnLHhk=
 github.com/onosproject/onos-lib-go v0.7.5/go.mod h1:mNFl7cjlVLLPXvFOnRXS/Lao+8p2XDREPViHdkElOPE=

--- a/pkg/ransim/nodes.go
+++ b/pkg/ransim/nodes.go
@@ -32,6 +32,8 @@ func getPlmnIDCommand() *cobra.Command {
 		Short: "Get the PLMNID",
 		RunE:  runGetPlmnIDCommand,
 	}
+
+	cmd.Flags().BoolP("string", "s", false, "string representation of plmnID")
 	return cmd
 }
 
@@ -129,6 +131,10 @@ func runGetPlmnIDCommand(cmd *cobra.Command, args []string) error {
 	resp, err := client.GetPlmnID(context.Background(), &modelapi.PlmnIDRequest{})
 	if err != nil {
 		return err
+	}
+	if stringRepresentation, _ := cmd.Flags().GetBool("string"); stringRepresentation {
+		cli.Output("%s\n", types.PlmnIDToString(resp.PlmnID))
+		return nil
 	}
 	cli.Output("%d\n", resp.PlmnID)
 	return nil


### PR DESCRIPTION
Per request, I added support for printing both representation of PlmnID. Not sure what is the best flag is for this: string (-s) or hex (-h). 
