### PR TITLE
Fix create relation bug

### DIFF
--- a/pkg/topo/create.go
+++ b/pkg/topo/create.go
@@ -57,7 +57,7 @@ func runCreateEntityCommand(cmd *cobra.Command, args []string) error {
 
 func runCreateRelationCommand(cmd *cobra.Command, args []string) error {
 	kindID, _ := cmd.Flags().GetString("kind")
-	return createObject(topoapi.NewRelation(topoapi.ID(args[0]), topoapi.ID(args[2]), topoapi.ID(kindID)), cmd)
+	return createObject(topoapi.NewRelation(topoapi.ID(args[0]), topoapi.ID(args[1]), topoapi.ID(kindID)), cmd)
 }
 
 func runCreateKindCommand(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Hi, I found a bug when creating a relation from cli.
`onos-cli-b987f85dd-snhxn:~$ onos topo create relation entity1 entity2
panic: runtime error: index out of range [2] with length 2

goroutine 1 [running]:
github.com/onosproject/onos-cli/pkg/topo.runCreateRelationCommand(0xc0004a4c00?, {0xc000470dc0, 0x2, 0x2?})
	/build/pkg/topo/create.go:60 +0x99
github.com/spf13/cobra.(*Command).execute(0xc0004a4c00, {0xc000470d80, 0x2, 0x2})
	/build/vendor/github.com/spf13/cobra/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc00049c000)
	/build/vendor/github.com/spf13/cobra/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/build/vendor/github.com/spf13/cobra/command.go:992
github.com/onosproject/onos-cli/pkg/cli.Execute()
	/build/pkg/cli/root.go:38 +0x1e
main.main()
	/build/cmd/onos/main.go:12 +0x17`

And this pull request is a fix. Thanks.